### PR TITLE
Wrap each surface render in a `with-blending` to fix the loss of alpha channel

### DIFF
--- a/desktop-mode.lisp
+++ b/desktop-mode.lisp
@@ -272,5 +272,6 @@
     (cepl:clear view-fbo))
   (cepl:with-blending (blending-parameters mode)
     (mapcar (lambda (surface)
-	      (render surface view-fbo))
+	      (cepl:with-blending (blending-parameters mode)
+		(render surface view-fbo)))
 	    (reverse (surfaces (view mode))))))


### PR DESCRIPTION
When more than one window was open, only a single window appeared to have
an alpha channel; at least on desktop-mode.

On alt-tab mode it was fine. The difference between the two modes was that
desktop-mode had a single `with-blending` call around the map across surfaces,
whereas alt-tab wraps every surface draw in that map with `with-blending`.

Applying the same to desktop-mode fixes it.

![screenshot](https://user-images.githubusercontent.com/2567177/42392233-041c2b72-814a-11e8-9dc8-37c779f25e6e.png)

Note that I tried moving the outer `with-blending` that was there to inside
the map. However, this seemed to lose the alpha channel of the cursor. Not
sure why. I need to understand FBOs and blending better.

Fixes https://github.com/malcolmstill/ulubis/issues/36