### PR TITLE
Fixed screenshot rgb order

### DIFF
--- a/screenshot.lisp
+++ b/screenshot.lisp
@@ -20,9 +20,9 @@
 		  (let ((i (* x bytes))
 			(j (* (- height y 1) width bytes)))
 		    (zpng:write-pixel
-		     (list (aref pixels (+ i j 0))
+		     (list (aref pixels (+ i j 2))
 			   (aref pixels (+ i j 1))
-			   (aref pixels (+ i j 2))
+			   (aref pixels (+ i j 0))
 			   255)
 		     png))))
 	(zpng:finish-png png)))))


### PR DESCRIPTION
Screenshots had the r and b components the wrong way around.

![fixed_screenshot_rgb_ordering](https://user-images.githubusercontent.com/2567177/42424872-1f39a66e-830c-11e8-91d5-8c5f75361320.png)
