### PR TITLE
Fixes #44

### DIFF
--- a/compositor.lisp
+++ b/compositor.lisp
@@ -92,7 +92,6 @@
 (defun remove-client (client-pointer)
   (let ((client (get-client client-pointer)))
     (loop :for resource :in (resources client) :do
-       (format t "resource: ~A~%" resource)
        (remove-surface resource *compositor*))
     (setf (resources client) nil)
     (setf waylisp::*clients* (remove-if (lambda (client)
@@ -104,11 +103,10 @@
     view))
 
 (defun views-with-surface (surface)
-  (loop :for view :in (views *compositor*)
+  (loop :for view :in (surfaces (screen *compositor*))
      :when (view-has-surface? surface view) :collect it))
 
 (defun remove-surface-from-view (surface view)
-  (format t "surface: ~A, view: ~A~%" surface view)
   (when (equalp (active-surface view) surface)
     (setf (active-surface view) nil))
   (setf (surfaces view) (remove surface (surfaces view))))

--- a/virtual-desktop-mode.lisp
+++ b/virtual-desktop-mode.lisp
@@ -100,12 +100,12 @@ the next.
 			      (setf (slide-animation mode) nil)
 			      (setf (old-surface mode) nil)
 			      (setf (new-surface mode) nil))
-			    (animation :duration 150
+			    (animation :duration 315
 				       :target new-surface
 				       :property 'x
 				       :to 0
 				       :easing-fn 'easing:in-out-exp)
-			    (animation :duration 150
+			    (animation :duration 315
 				       :target old-surface
 				       :property 'x
 				       :to (* -1 mult (screen-width *compositor*))

--- a/zxdg-toplevel-v6-impl.lisp
+++ b/zxdg-toplevel-v6-impl.lisp
@@ -2,7 +2,7 @@
 (in-package :ulubis)
 
 (def-wl-callback set-title (client toplevel (title :string))
-  (format t "Setting title of ~A to ~A~%" toplevel title))
+  )
 
 (def-wl-callback move (client toplevel (seat :pointer) (serial :uint32))
   (setf (moving-surface *compositor*) (make-move-op :surface toplevel


### PR DESCRIPTION
`view-with-surfaces` was still looking for `(views *compositor*)` instead of `(surfaces (screen *compositor*))`

Also some changes to virtual desktop animation and removal of a `format`