### PR TITLE
Fixes #31

### DIFF
--- a/ulubis.asd
+++ b/ulubis.asd
@@ -46,6 +46,8 @@
 	       (:file "zxdg-toplevel-v6-impl")
 	       (:file "zxdg-surface-v6-impl")
 	       (:file "zxdg-shell-v6-impl")
+	       (:file "zxdg-positioner-v6-impl")
+	       (:file "zxdg-popup-v6-impl")
 	       (:file "xdg-surface-impl")
 	       (:file "xdg-shell-impl")
 	       (:file "screenshot")

--- a/ulubis.lisp
+++ b/ulubis.lisp
@@ -218,6 +218,8 @@ moving it back. If views are also isurfaces that should be within ulubis.
 	 (set-implementation-zxdg-shell-v6)
 	 (set-implementation-zxdg-surface-v6)
 	 (set-implementation-zxdg-toplevel-v6)
+	 (set-implementation-zxdg-positioner-v6)
+	 (set-implementation-zxdg-popup-v6)
 	 (set-implementation-xdg-shell)
 	 (set-implementation-xdg-surface)
 

--- a/zxdg-popup-v6-impl.lisp
+++ b/zxdg-popup-v6-impl.lisp
@@ -1,0 +1,24 @@
+
+(in-package :ulubis)
+
+(def-wl-callback grab (client zxdg-popup (seat :pointer) (serial :uint32))
+  (format t "grab: ~A ~A~%" seat serial))
+
+(def-wl-delete zxdg-popup-delete (popup)
+  (when popup
+    (setf (role (wl-surface popup)) nil)
+    (remove-surface popup *compositor*)
+    (setf (render-needed *compositor*) t)))
+
+(def-wl-callback zxdg-popup-destroy (client popup)
+  (when popup
+    (setf (role (wl-surface popup)) nil)
+    (remove-surface popup *compositor*)
+    (setf (render-needed *compositor*) t)))
+
+(defimplementation zxdg-popup-v6 (isurface ianimatable)
+  ((:grab grab)
+   (:destroy zxdg-popup-destroy))
+  ((zxdg-surface-v6 :accessor zxdg-surface-v6
+		    :initarg :zxdg-surface-v6
+		    :initform nil)))

--- a/zxdg-positioner-v6-impl.lisp
+++ b/zxdg-positioner-v6-impl.lisp
@@ -1,0 +1,29 @@
+
+(in-package :ulubis)
+
+(def-wl-callback set-size (client zxdg-positioner (width :uint32) (height :uint32))
+  (format t "set-size: ~A ~A~%" width height))
+
+(def-wl-callback set-anchor-rect (client zxdg-positioner (x :uint32) (y :uint32) (width :uint32) (height :uint32))
+  (format t "set-anchor-rect: ~A ~A ~A ~A~%" x y width height))
+
+(def-wl-callback set-anchor (client zxdg-positioner (anchor :uint32))
+  (format t "set-anchor: ~A~%" anchor))
+
+(def-wl-callback set-gravity (client zxdg-positioner (gravity :uint32))
+  (format t "set-gravity: ~A~%" gravity))
+
+(def-wl-callback set-constraint-adjustment (client zxdg-positioner (constraint-adjustment :uint32))
+  (format t "set-constraint-adjustment: ~A~%" constraint-adjustment))
+
+(def-wl-callback set-offset (client zxdg-positioner (x :uint32) (y :uint32))
+  (format t "set-offset: ~A ~A~%" x y))
+
+(defimplementation zxdg-positioner-v6 ()
+  ((:set-size set-size)
+   (:set-anchor-rect set-anchor-rect)
+   (:set-anchor set-anchor)
+   (:set-gravity set-gravity)
+   (:set-constraint-adjustment set-constraint-adjustment)
+   (:set-offset set-offset))
+  ())

--- a/zxdg-shell-v6-impl.lisp
+++ b/zxdg-shell-v6-impl.lisp
@@ -7,8 +7,12 @@
     (setf (wl-surface zxdg-surface) surface)
     (setf (role surface) zxdg-surface)))
 
+(def-wl-callback create-positioner (client zxdg-shell (id :uint32))
+  (make-zxdg-positioner-v6 client 1 id))
+
 (defimplementation zxdg-shell-v6 ()
-  ((:get-xdg-surface get-xdg-surface))
+  ((:get-xdg-surface get-xdg-surface)
+   (:create-positioner create-positioner))
   ())
 
 (def-wl-delete client-delete (zxdg-shell)

--- a/zxdg-surface-v6-impl.lisp
+++ b/zxdg-surface-v6-impl.lisp
@@ -15,6 +15,17 @@
       (zxdg-toplevel-v6-send-configure (->resource toplevel) 0 0 array)
       (zxdg-surface-v6-send-configure (->resource zxdg-surface) 0))))
 
+(def-wl-callback get-popup (client zxdg-surface (id :uint32) (parent :pointer) (positioner :pointer))
+  (let ((popup (make-zxdg-popup-v6 client 1 id :delete-fn (callback zxdg-popup-delete))))
+    (setf (zxdg-surface-v6 popup) zxdg-surface)
+    (setf (role (wl-surface zxdg-surface)) popup)
+    (setf (wl-surface popup) (wl-surface zxdg-surface))
+    (push popup (surfaces (active-surface (screen *compositor*))))
+    (with-wl-array array
+      (zxdg-popup-v6-send-configure (->resource popup) 0 0 1 1)
+      (zxdg-surface-v6-send-configure (->resource zxdg-surface) 0))))
+
 (defimplementation zxdg-surface-v6 (isurface)
-  ((:get-toplevel get-toplevel))
+  ((:get-toplevel get-toplevel)
+   (:get-popup get-popup))
   ())


### PR DESCRIPTION
Fixes the crash in issue #31. The implementation of popup and positioner
are mostly placeholders, but this does stop the crash.

Further work will be required to sensibly utilise these protocols:
- obey positioner where we can
- when we receive a grab request ensure focus on the popup along with
  some graphical effect (e.g. fade out the rest of the desktop)