### PR TITLE
Finally support resizing from borders

### DIFF
--- a/compositor.lisp
+++ b/compositor.lisp
@@ -135,7 +135,8 @@
   pointer-x
   pointer-y
   surface-width
-  surface-height)
+  surface-height
+  direction)
 
 ;; Check pointer is over client
 ;; If it is and there is no input-region return true

--- a/surface.lisp
+++ b/surface.lisp
@@ -19,3 +19,13 @@
 				0
 				0
 				0)))
+
+(defun effective-width (surface)
+  (if (input-region (wl-surface surface))
+      (width (first (last (rects (input-region (wl-surface surface))))))
+      (width (wl-surface surface))))
+
+(defun effective-height (surface)
+  (if (input-region (wl-surface surface))
+      (height (first (last (rects (input-region (wl-surface surface))))))
+      (height (wl-surface surface))))

--- a/zxdg-toplevel-v6-impl.lisp
+++ b/zxdg-toplevel-v6-impl.lisp
@@ -11,6 +11,15 @@
 						    :pointer-x (pointer-x *compositor*)
 						    :pointer-y (pointer-y *compositor*))))
 
+(def-wl-callback resize (client toplevel (seat :pointer) (serial :uint32) (edges :uint32))
+  (setf (resizing-surface *compositor*)
+	(make-resize-op :surface toplevel
+			:pointer-x (pointer-x *compositor*)
+			:pointer-y (pointer-y *compositor*)
+			:surface-width (effective-width toplevel)
+			:surface-height (effective-height toplevel)
+			:direction edges)))
+
 (def-wl-callback zxdg-toplevel-destroy (client toplevel)
   (setf (role (wl-surface toplevel)) nil)
   (remove-surface toplevel *compositor*)
@@ -24,6 +33,7 @@
 
 (defimplementation zxdg-toplevel-v6 (isurface ianimatable)
   ((:move move)
+   (:resize resize)
    (:destroy zxdg-toplevel-destroy)
    (:set-title set-title))
   ((zxdg-surface-v6 :accessor zxdg-surface-v6


### PR DESCRIPTION
Currently this only supports resizing from bottom, right
and bottom right edges. This is because we also need to
update the surface x and y if resizing from other edges.

I did implement that but my naive implementation didn't
really play nice. The size of weston-terminal does not
increase in pixel increments, rather it needs a minimum
resize size in order to actually update its width and
height. If I just modify x with delta-x and y with delta-y
the bottom and right edges are not fixed as they should be
but rather "vibrate". I need to think about how to solve
this properly.