### PR TITLE
Support EGL

### DIFF
--- a/backend.lisp
+++ b/backend.lisp
@@ -15,7 +15,13 @@
    destroy-backend
    event-loop-add-drm-fd
    set-scheduled
-   get-scheduled))
+   get-scheduled
+   init-egl
+   egl-supported?
+   egl-surface?
+   egl-get-dimensions
+   egl-texture-from-image
+   ))
 
 (in-package :ulubis-backend)
 
@@ -29,6 +35,11 @@
 (defgeneric register-window-event-handler (backend keyboard-handler)) ;; Useful if running on X
 (defgeneric swap-buffers (backend))
 (defgeneric destroy-backend (backend))
+(defgeneric init-egl (backend wl-display))
+(defgeneric egl-supported? (backend))
+(defgeneric egl-surface? (backend buffer))
+(defgeneric egl-get-dimensions (backend buffer))
+(defgeneric egl-texture-from-image (backend buffer width height))
 
 ;; DRM backend only
 (defgeneric event-loop-add-drm-fd (backend event-loop))

--- a/wallpaper.lisp
+++ b/wallpaper.lisp
@@ -1,0 +1,3 @@
+
+(in-package :ulubis)
+

--- a/wl-seat-impl.lisp
+++ b/wl-seat-impl.lisp
@@ -8,7 +8,7 @@
   (let ((keyboard (make-wl-keyboard client (get-version seat) id)))
     (setf (keyboard client) keyboard)
     (when (>= (get-version keyboard) 4)
-      (wl-keyboard-send-repeat-info (->resource keyboard) 30 200)
+      ;;(wl-keyboard-send-repeat-info (->resource keyboard) 30 200)
       (multiple-value-bind (fd size) (get-keymap *compositor*)
 	(wl-keyboard-send-keymap (->resource keyboard) 1 fd size)))))
 


### PR DESCRIPTION
Fixes #3. 

![screenshot](https://user-images.githubusercontent.com/2567177/43165979-2efc04d8-8f8d-11e8-89cf-5601390da50d.png)

Note I've commented out 
```
(wl-keyboard-send-repeat-info (->resource keyboard) 30 200)
```
as this was crashing `weston-simple-egl`. Need to figure out why.